### PR TITLE
nudging the mouse numbers to be accurate for equipment test

### DIFF
--- a/data/issue_1489.json
+++ b/data/issue_1489.json
@@ -3474,8 +3474,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 384,
-                "y": 193
+                "x": 368,
+                "y": 177
             },
             "type": "mouseMove"
         },
@@ -3484,8 +3484,8 @@
             "buttons": "left",
             "isDoubleClick": false,
             "pos": {
-                "x": 384,
-                "y": 193
+                "x": 368,
+                "y": 177
             },
             "type": "mouseButtonPress"
         },
@@ -3499,8 +3499,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 384,
-                "y": 193
+                "x": 368,
+                "y": 177
             },
             "type": "mouseButtonRelease"
         },
@@ -5974,8 +5974,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 289,
-                "y": 218
+                "x": 273,
+                "y": 202
             },
             "type": "mouseMove"
         },
@@ -5994,8 +5994,8 @@
             "buttons": "left",
             "isDoubleClick": false,
             "pos": {
-                "x": 289,
-                "y": 218
+                "x": 273,
+                "y": 202
             },
             "type": "mouseButtonPress"
         },
@@ -6014,8 +6014,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 289,
-                "y": 218
+                "x": 273,
+                "y": 202
             },
             "type": "mouseButtonRelease"
         },
@@ -6484,8 +6484,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 255,
-                "y": 217
+                "x": 239,
+                "y": 201
             },
             "type": "mouseMove"
         },
@@ -6509,8 +6509,8 @@
             "buttons": "left",
             "isDoubleClick": false,
             "pos": {
-                "x": 255,
-                "y": 217
+                "x": 239,
+                "y": 201
             },
             "type": "mouseButtonPress"
         },
@@ -6529,8 +6529,8 @@
             "buttons": "none",
             "isDoubleClick": false,
             "pos": {
-                "x": 255,
-                "y": 217
+                "x": 239,
+                "y": 201
             },
             "type": "mouseButtonRelease"
         },


### PR DESCRIPTION
This pull request updates the `data/issue_1489.json` file to adjust the `pos` coordinates for mouse events. The changes ensure that the x and y positions are consistent with updated requirements or specifications.

### Adjustments to mouse event coordinates:

* Updated `pos` coordinates for `mouseMove`, `mouseButtonPress`, and `mouseButtonRelease` events from `(384, 193)` to `(368, 177)` in one section. [[1]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L3477-R3478) [[2]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L3487-R3488) [[3]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L3502-R3503)
* Updated `pos` coordinates for `mouseMove`, `mouseButtonPress`, and `mouseButtonRelease` events from `(289, 218)` to `(273, 202)` in another section. [[1]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L5977-R5978) [[2]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L5997-R5998) [[3]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L6017-R6018)
* Updated `pos` coordinates for `mouseMove`, `mouseButtonPress`, and `mouseButtonRelease` events from `(255, 217)` to `(239, 201)` in a third section. [[1]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L6487-R6488) [[2]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L6512-R6513) [[3]](diffhunk://#diff-4b63301939db470e36afa45b1b3c5e882c2275d96683e6585c45af94324b80b2L6532-R6533)